### PR TITLE
Fix Canadian Dollar typo

### DIFF
--- a/currencies.xml
+++ b/currencies.xml
@@ -23,7 +23,7 @@
   </currency>
   <currency>
     <id>4</id>
-    <title>Canadian Collar</title>
+    <title>Canadian Dollar</title>
     <abbr>CAD</abbr>
     <symbol>$</symbol>
     <position>0</position>


### PR DESCRIPTION
Quick fix for a typo in currencies.xml. Canadian Dollar was written Canadian Collar.